### PR TITLE
Implement proper namespaces

### DIFF
--- a/advanced-post-excerpt.php
+++ b/advanced-post-excerpt.php
@@ -14,22 +14,24 @@
  * @author  Steve Grunwell
  */
 
+namespace AdvancedPostExcerpt;
+
 /**
  * Load the plugin textdomain.
  */
-function ape_load_plugin_textdomain() {
+function load_textdomain() {
 	load_plugin_textdomain(
 		'advanced-post-excerpt',
 		false,
 		dirname( plugin_basename( __FILE__ ) ) . '/languages'
 	);
 }
-add_action( 'init', 'ape_load_plugin_textdomain' );
+add_action( 'init', __NAMESPACE__ . '\load_textdomain' );
 
 /**
  * Replace the default 'postexcerpt' meta box.
  */
-function ape_replace_postexcerpt_meta_box() {
+function replace_metabox() {
 	$post_types = get_post_types_by_support( 'excerpt' );
 
 	/**
@@ -46,20 +48,20 @@ function ape_replace_postexcerpt_meta_box() {
 	add_meta_box(
 		'postexcerpt',
 		_x( 'Excerpt', 'meta box heading', 'advanced-post-excerpt' ),
-		'ape_post_excerpt_meta_box',
+		__NAMESPACE__ . '\render_metabox',
 		$post_types,
 		'normal',
 		'high'
 	);
 }
-add_action( 'add_meta_boxes', 'ape_replace_postexcerpt_meta_box' );
+add_action( 'add_meta_boxes', __NAMESPACE__ . '\replace_metabox' );
 
 /**
  * Replace the meta box contents.
  *
  * @param WP_Post $post The current post object.
  */
-function ape_post_excerpt_meta_box( $post ) {
+function render_metabox( $post ) {
 	$settings = array(
 		'media_buttons' => false,
 		'teeny'         => true,
@@ -84,7 +86,7 @@ function ape_post_excerpt_meta_box( $post ) {
  * @param string $editor_id A unique identifier for the TinyMCE instance.
  * @return array The $buttons array, minus alignment actions.
  */
-function ape_remove_alignment_buttons_from_excerpt( $buttons, $editor_id ) {
+function remove_alignment_buttons( $buttons, $editor_id ) {
 	if ( 'excerpt' === $editor_id ) {
 		$buttons = array_values(
 			array_diff( $buttons, [ 'alignleft', 'alignright', 'aligncenter' ] )
@@ -93,4 +95,4 @@ function ape_remove_alignment_buttons_from_excerpt( $buttons, $editor_id ) {
 
 	return $buttons;
 }
-add_filter( 'teeny_mce_buttons', 'ape_remove_alignment_buttons_from_excerpt', 10, 2 );
+add_filter( 'teeny_mce_buttons', __NAMESPACE__ . '\remove_alignment_buttons', 10, 2 );

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -10,6 +10,12 @@ namespace Tests;
 
 use SteveGrunwell\PHPUnit_Markup_Assertions\MarkupAssertionsTrait;
 use WP_UnitTestCase;
+use function AdvancedPostExcerpt\{
+	load_textdomain,
+	replace_metabox,
+	render_metabox,
+	remove_alignment_buttons
+};
 
 class CoreTest extends WP_UnitTestCase {
 
@@ -23,13 +29,13 @@ class CoreTest extends WP_UnitTestCase {
 
 		$wp_actions = [];
 
-		ape_load_plugin_textdomain();
+		load_textdomain();
 
 		$this->assertGreaterThan( 1, did_action( 'load_textdomain' ) );
 	}
 
 	public function test_replaces_default_post_excerpt_meta_box() {
-		ape_replace_postexcerpt_meta_box();
+		replace_metabox();
 
 		$this->assertTrue(
 			$this->post_type_has_advanced_post_excerpt( 'post' ),
@@ -48,7 +54,7 @@ class CoreTest extends WP_UnitTestCase {
 	 *           ["user_request"]
 	 */
 	public function test_only_replaces_on_post_types_that_support_excerpts( $post_type ) {
-		ape_replace_postexcerpt_meta_box();
+		replace_metabox();
 
 		$this->assertFalse(
 			$this->post_type_has_advanced_post_excerpt( $post_type ),
@@ -61,7 +67,7 @@ class CoreTest extends WP_UnitTestCase {
 			return [ 'some-post-type' ];
 		} );
 
-		ape_replace_postexcerpt_meta_box();
+		replace_metabox();
 
 		$this->assertTrue(
 			$this->post_type_has_advanced_post_excerpt( 'some-post-type' ),
@@ -75,7 +81,7 @@ class CoreTest extends WP_UnitTestCase {
 		] );
 
 		ob_start();
-		ape_post_excerpt_meta_box( $post );
+		render_metabox( $post );
 		$rendered = ob_get_clean();
 
 		$this->assertContainsSelector(
@@ -101,7 +107,7 @@ class CoreTest extends WP_UnitTestCase {
 		} );
 
 		ob_start();
-		ape_post_excerpt_meta_box( $post );
+		render_metabox( $post );
 		$rendered = ob_get_clean();
 
 		$this->assertContainsSelector(
@@ -117,7 +123,7 @@ class CoreTest extends WP_UnitTestCase {
 		] );
 
 		ob_start();
-		ape_post_excerpt_meta_box( $post );
+		render_metabox( $post );
 		$rendered = ob_get_clean();
 
 		$this->assertContains(
@@ -135,19 +141,19 @@ class CoreTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			[ 'bold', 'italic', 'link' ],
-			ape_remove_alignment_buttons_from_excerpt( $buttons, 'excerpt' )
+			remove_alignment_buttons( $buttons, 'excerpt' )
 		);
 	}
 
 	/**
 	 * @ticket https://github.com/stevegrunwell/advanced-post-excerpt/issues/2
 	 */
-	public function test_does_only_removes_alignment_buttons_from_excerpt() {
+	public function test_only_removes_alignment_buttons_from_excerpt() {
 		$buttons = [ 'bold', 'italic', 'alignleft', 'alignright', 'aligncenter', 'link' ];
 
 		$this->assertSame(
 			$buttons,
-			ape_remove_alignment_buttons_from_excerpt( $buttons, 'not-the-excerpt' )
+			remove_alignment_buttons( $buttons, 'not-the-excerpt' )
 		);
 	}
 
@@ -167,7 +173,7 @@ class CoreTest extends WP_UnitTestCase {
 			&& $wp_meta_boxes[ $post_type ]['normal']['high']['postexcerpt'] === [
 				'id'       => 'postexcerpt',
 				'title'    => _x( 'Excerpt', 'meta box heading', 'advanced-post-excerpt' ),
-				'callback' => 'ape_post_excerpt_meta_box',
+				'callback' => 'AdvancedPostExcerpt\render_metabox',
 				'args'     => null,
 			];
 	}


### PR DESCRIPTION
There are only a few functions (and it's all procedural code), but if we don't have to support PHP < 5.3 there's no good reason to write as if we do.

Fixes #7.