### PR TITLE
Make the plugin compatible with the block editor

### DIFF
--- a/advanced-post-excerpt.php
+++ b/advanced-post-excerpt.php
@@ -51,7 +51,10 @@ function replace_metabox() {
 		__NAMESPACE__ . '\render_metabox',
 		$post_types,
 		'normal',
-		'high'
+		'high',
+		array(
+			'__back_compat_meta_box' => false,
+		)
 	);
 }
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\replace_metabox' );
@@ -96,3 +99,15 @@ function remove_alignment_buttons( $buttons, $editor_id ) {
 	return $buttons;
 }
 add_filter( 'teeny_mce_buttons', __NAMESPACE__ . '\remove_alignment_buttons', 10, 2 );
+
+/**
+ * Register the script to remove the "Post Excerpt" panel from the block editor.
+ */
+function remove_panel_from_block_editor() {
+	wp_enqueue_script(
+		'advanced-post-excerpt',
+		plugins_url( 'js/advanced-post-excerpt.js', __FILE__ ),
+		array( 'wp-edit-post' )
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\remove_panel_from_block_editor' );

--- a/advanced-post-excerpt.php
+++ b/advanced-post-excerpt.php
@@ -16,6 +16,8 @@
 
 namespace AdvancedPostExcerpt;
 
+define( __NAMESPACE__ . '\PLUGIN_VERSION', '1.0.0' );
+
 /**
  * Load the plugin textdomain.
  */
@@ -107,7 +109,9 @@ function remove_panel_from_block_editor() {
 	wp_enqueue_script(
 		'advanced-post-excerpt',
 		plugins_url( 'js/advanced-post-excerpt.js', __FILE__ ),
-		array( 'wp-edit-post' )
+		array( 'wp-edit-post' ),
+		PLUGIN_VERSION,
+		true
 	);
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\remove_panel_from_block_editor' );

--- a/js/advanced-post-excerpt.js
+++ b/js/advanced-post-excerpt.js
@@ -1,0 +1,10 @@
+/**
+ * Scripting for the Advanced Post Excerpt plugin.
+ *
+ * @package AdvancedPostExcerpt
+ * @author  Steve Grunwell
+ */
+
+// Remove the default "Post Excerpt" panel from the block editor.
+wp.data.dispatch( 'core/edit-post')
+	.removeEditorPanel( 'post-excerpt' );

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -158,6 +158,17 @@ class CoreTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket https://github.com/stevegrunwell/advanced-post-excerpt/issues/4
+	 */
+	public function test_registers_block_editor_js() {
+		$this->assertFalse( wp_script_is( 'advanced-post-excerpt', 'enqueued' ) );
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		$this->assertTrue( wp_script_is( 'advanced-post-excerpt', 'enqueued' ) );
+	}
+
+	/**
 	 * Determine if the given post type has the Advanced Post Excerpt.
 	 *
 	 * @global $wp_meta_boxes
@@ -174,7 +185,9 @@ class CoreTest extends WP_UnitTestCase {
 				'id'       => 'postexcerpt',
 				'title'    => _x( 'Excerpt', 'meta box heading', 'advanced-post-excerpt' ),
 				'callback' => 'AdvancedPostExcerpt\render_metabox',
-				'args'     => null,
+				'args'     => [
+					'__back_compat_meta_box' => false,
+				],
 			];
 	}
 }


### PR DESCRIPTION
This commit does two things to ensure compatibility with the WordPress block editor (a.k.a. "Gutenberg"):

1. When overriding the registration of the "postexcerpt" meta box, explicitly set `__back_compat_meta_box` to `false`, preventing the block editor from suppressing the meta box.
2. Load a bit of JavaScript (when the block editor is active) that removes the Gutenberg-default "Post Excerpt" panel (which only includes a textarea).

Fixes #4.